### PR TITLE
fix(generation): update file.mtime if an imported style file is fresher

### DIFF
--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -7,12 +7,14 @@ export const application = {
 export const emptyFile = {
 	buffer: new Buffer(''),
 	path: 'empty/index.jsx',
-	dependencies: {}
+	dependencies: {},
+	fs: {node: {mtime: 0}}
 };
 
 export const plainFile = {
 	buffer: new Buffer('<div />'),
-	dependencies: {}
+	dependencies: {},
+	fs: {node: {mtime: 0}}
 };
 
 export const statelessFile = {
@@ -22,7 +24,8 @@ export const statelessFile = {
 	};
 	`)),
 	path: 'stateless/index.jsx',
-	dependencies: {}
+	dependencies: {},
+	fs: {node: {mtime: 0}}
 };
 
 export const fullFile = {
@@ -36,5 +39,6 @@ export const fullFile = {
 	}
 	`)),
 	path: 'full/index.jsx',
-	dependencies: {}
+	dependencies: {},
+	fs: {node: {mtime: 0}}
 };


### PR DESCRIPTION
if an imported style file is changed we need to change the mtime of the
markup/jsx file because we are changing the contents of that file's
buffer so that the following transforms can cache correctly.

fixes: nerdlabs/patternplate-transform-cssmodules#4
